### PR TITLE
3.4

### DIFF
--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -150,7 +150,8 @@ packet_stats(struct timeval *begin, struct timeval *end,
             pkts_sent, bytes_sent, frac_sec);
     printf("Rated: %.1f Bps, %.2f Mbps, %.2f pps\n",
            bytes_sec, mb_sec, pkts_sec);
-
+    fflush(NULL);
+           
     if (failed)
         printf(COUNTER_SPEC " write attempts failed from full buffers and were repeated\n",
               failed);

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -70,6 +70,7 @@ extern volatile int didsig;
 extern int debug;
 #endif
 
+struct timeval last, last_print_time;
 
 /**
  * the main loop function for tcpreplay.  This is where we figure out
@@ -78,7 +79,7 @@ extern int debug;
 void
 send_packets(pcap_t *pcap, int cache_file_idx)
 {
-    struct timeval last = { 0, 0 }, last_print_time = { 0, 0 }, print_delta, now;
+    struct timeval print_delta, now;
     COUNTER packetnum = 0;
     struct pcap_pkthdr pkthdr;
     const u_char *pktdata = NULL;

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -94,7 +94,6 @@ send_packets(pcap_t *pcap, int cache_file_idx)
     init_delta_time(&delta_ctx);
 
     /* register signals */
-    didsig = 0;
     if (options.speed.mode != SPEED_ONEATATIME) {
         (void)signal(SIGINT, catcher);
     } else {


### PR DESCRIPTION
Fix ^C handling when looping small files (didsig got reset to 0 before it was ever checked in the code, typically during sendpacket_get_dlt() when -K not used, even with -K it was a bit sporadic)

Preserve last and last_print_time so --stats works when looping small pcaps
