### PR TITLE
fix crash on close

### DIFF
--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -371,7 +371,6 @@ tcpreplay_close(tcpreplay_t *ctx)
             safe_free(packet_cache);
             packet_cache = next;
         }
-        safe_free(options->file_cache);
     }
 
     /* free our interface list */


### PR DESCRIPTION
options->file_cache is not a pointer and therefore if this is executed the program will crash
