### PR TITLE
Enhancement mbps option accuracy

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -55,7 +55,7 @@ extern int debug;
 
 static void do_sleep(tcpreplay_t *ctx, struct timeval *time, 
         struct timeval *last, int len, tcpreplay_accurate accurate, 
-        sendpacket_t *sp, COUNTER counter, delta_t *delta_ctx);
+        sendpacket_t *sp, COUNTER counter, delta_t *delta_ctx, bool *skip_timestamp);
 static const u_char *get_next_packet(tcpreplay_t *ctx, pcap_t *pcap, 
         struct pcap_pkthdr *pkthdr, int file_idx, packet_cache_t **prev_packet);
 static u_int32_t get_user_count(tcpreplay_t *ctx, sendpacket_t *sp, COUNTER counter);
@@ -116,6 +116,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
     struct pcap_pkthdr *pkthdr_ptr;
 #endif
     delta_t delta_ctx;
+    bool skip_timestamp = false;
 
     init_delta_time(&delta_ctx);
 
@@ -179,12 +180,15 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
          * had to be special and use bpf_timeval.
          * Only sleep if we're not in top speed mode (-t)
          */
-        if (ctx->options->speed.mode != speed_topspeed)
+        if (ctx->options->speed.mode != speed_topspeed && ctx->options->speed.speed)
             do_sleep(ctx, (struct timeval *)&pkthdr.ts, &last, pktlen, 
-                    ctx->options->accurate, sp, packetnum, &delta_ctx);
+                    ctx->options->accurate, sp, packetnum, &delta_ctx,
+                    &skip_timestamp);
 
-        /* mark the time when we send the last packet */
-        start_delta_time(&delta_ctx);
+        if (!skip_timestamp)
+            /* mark the time when we send the last packet */
+            start_delta_time(&delta_ctx);
+
         dbgx(2, "Sending packet #" COUNTER_SPEC, packetnum);
 
         /* write packet out on network */
@@ -244,6 +248,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int idx1, pcap_t *pcap2, int 
     /* ???? */
     int idx;
     pcap_t *pcap;
+    bool skip_timestamp = false;
 
     init_delta_time(&delta_ctx);
 
@@ -344,12 +349,14 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int idx1, pcap_t *pcap2, int 
          * had to be special and use bpf_timeval.
          * Only sleep if we're not in top speed mode (-t)
          */
-        if (ctx->options->speed.mode != speed_topspeed)
+        if (ctx->options->speed.mode != speed_topspeed && ctx->options->speed.speed)
             do_sleep(ctx, (struct timeval *)&pkthdr_ptr->ts, &last, pktlen,
-                    ctx->options->accurate, sp, packetnum, &delta_ctx);
+                    ctx->options->accurate, sp, packetnum, &delta_ctx, &skip_timestamp);
 
-        /* mark the time when we send the last packet */
-        start_delta_time(&delta_ctx);
+        if (!skip_timestamp)
+            /* mark the time when we send the last packet */
+            start_delta_time(&delta_ctx);
+
         dbgx(2, "Sending packet #" COUNTER_SPEC, packetnum);
 
         /* write packet out on network */
@@ -530,22 +537,21 @@ cache_mode(tcpreplay_t *ctx, char *cachedata, COUNTER packet_num)
 static void
 do_sleep(tcpreplay_t *ctx, struct timeval *time, struct timeval *last, 
         int len, tcpreplay_accurate accurate, sendpacket_t *sp, 
-        COUNTER counter, delta_t *delta_ctx)
+        COUNTER counter, delta_t *delta_ctx, bool *skip_timestamp)
 {
-    static struct timeval didsleep = { 0, 0 };
-    static struct timeval start = { 0, 0 };
 #ifdef DEBUG
     static struct timeval totalsleep = { 0, 0 };
 #endif
     struct timespec adjuster = { 0, 0 };
     static struct timespec nap = { 0, 0 }, delta_time = {0, 0};
-    struct timeval nap_for, now, sleep_until;
+    struct timeval nap_for;
     struct timespec nap_this_time;
     static int32_t nsec_adjuster = -1, nsec_times = -1;
-    float n;
     static u_int32_t send = 0;      /* accellerator.   # of packets to send w/o sleeping */
     u_int64_t ppnsec; /* packets per usec */
     static int first_time = 1;      /* need to track the first time through for the pps accelerator */
+    static COUNTER skip_length = 0;
+    COUNTER now_us, mbps;
 
 
 #ifdef TCPREPLAY
@@ -555,7 +561,22 @@ do_sleep(tcpreplay_t *ctx, struct timeval *time, struct timeval *last,
     adjuster.tv_nsec = 0;
 #endif
 
-    /* acclerator time? */
+    /*
+     * this accelerator improves performance by avoiding expensive
+     * time stamps during periods where we have fallen behind in our
+     * sending
+     */
+    if (*skip_timestamp) {
+        if ((COUNTER)len < skip_length) {
+            skip_length -= len;
+            return;
+        }
+
+        skip_length = 0;
+        *skip_timestamp = false;
+    }
+
+    /* accelerator time? */
     if (send > 0) {
         send --;
         return;
@@ -575,21 +596,6 @@ do_sleep(tcpreplay_t *ctx, struct timeval *time, struct timeval *last,
 
     dbgx(4, "This packet time: " TIMEVAL_FORMAT, time->tv_sec, time->tv_usec);
     dbgx(4, "Last packet time: " TIMEVAL_FORMAT, last->tv_sec, last->tv_usec);
-
-    if (gettimeofday(&now, NULL) < 0)
-        errx(-1, "Error gettimeofday: %s", strerror(errno));
-
-    dbgx(4, "Now time: " TIMEVAL_FORMAT, now.tv_sec, now.tv_usec);
-
-    /* First time through for this file */
-    if (ctx->stats.pkts_sent == 0 || ((ctx->options->speed.mode != speed_mbpsrate) && (counter == 0))) {
-        start = now;
-        timerclear(&sleep_until);
-        timerclear(&didsleep);
-    }
-    else {
-        timersub(&now, &start, &sleep_until);
-    }
 
     /* If top speed, you shouldn't even be here */
     assert(ctx->options->speed.mode != speed_topspeed);
@@ -625,19 +631,29 @@ do_sleep(tcpreplay_t *ctx, struct timeval *time, struct timeval *last,
          * Ignore the time supplied by the capture file and send data at
          * a constant 'rate' (bytes per second).
          */
-        if (ctx->stats.pkts_sent != 0) {
-            n = (float)len / (ctx->options->speed.speed * 1000 * 1000 / 8); /* convert Mbps to bps */
-            nap.tv_sec = n;
-            nap.tv_nsec = (n - nap.tv_sec)  * 1000000000;
-
-            dbgx(3, "packet size %d\t\tequals %f bps\t\tnap " TIMESPEC_FORMAT, len, n, 
-                nap.tv_sec, nap.tv_nsec);
+        timesclear(&nap_this_time);
+        now_us = TIMEVAL_TO_MICROSEC(delta_ctx);
+        if (now_us) {
+            mbps = (COUNTER)ctx->options->speed.speed;
+            COUNTER bits_sent = (ctx->stats.bytes_sent * 8);
+            COUNTER next_tx_us = bits_sent / mbps;    /* bits divided by Mbps = microseconds */
+            COUNTER tx_us = now_us - TIMEVAL_TO_MICROSEC(&ctx->stats.start_time);
+            COUNTER delta_us = (next_tx_us > tx_us) ? next_tx_us - tx_us : 0;
+            if (delta_us)
+                /* have to sleep */
+                NANOSEC_TO_TIMESPEC(delta_us* 1000, &nap_this_time);
+            else {
+                /*
+                 * calculate how many bytes we are behind and don't bother
+                 * time stamping until we have caught up
+                 */
+                skip_length = ((tx_us - next_tx_us) * mbps) / 8;
+                *skip_timestamp = true;
+            }
         }
-        else {
-            /* don't sleep at all for the first packet */
-            timesclear(&nap);
-        }
-        break;
+        dbgx(3, "packet size %d\t\tequals %f bps\t\tnap " TIMESPEC_FORMAT, len, n,
+            nap.tv_sec, nap.tv_nsec);
+        goto sleep_now;
 
     case speed_packetrate:
         /* only need to calculate this the first time */
@@ -737,6 +753,7 @@ do_sleep(tcpreplay_t *ctx, struct timeval *time, struct timeval *last,
         }
     }
 
+sleep_now:
     dbgx(2, "Sleeping:                   " TIMESPEC_FORMAT, nap_this_time.tv_sec, nap_this_time.tv_nsec);
 
     /* don't sleep if nap = {0, 0} */

--- a/src/tcpedit/plugins/dlt_utils.c
+++ b/src/tcpedit/plugins/dlt_utils.c
@@ -173,7 +173,7 @@ tcpedit_dlt_validate(tcpeditdlt_t *ctx)
     
     /* loops from 1 -> UINT32_MAX by powers of 2 */
     for (bit = 1; bit != 0; bit = bit << 2) {
-        if (ctx->encoder->requires & bit && ! ctx->decoder->provides & bit) {
+        if ((ctx->encoder->requires & bit) && ! (ctx->decoder->provides & bit)) {
             tcpedit_seterr(ctx->tcpedit, "%s", tcpeditdlt_bit_info[tcpeditdlt_bit_map[bit]]);
             return TCPEDIT_ERROR;
         }            

--- a/src/tcpreplay.c
+++ b/src/tcpreplay.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
     }
 
     for (i = 0; i < argc; i++) {
-        ctx->options->sources[i].filename = safe_strdup(argv[i]);
+        tcpreplay_add_pcapfile(ctx, argv[i]);
 
         /* preload our pcap file? */
         if (ctx->options->preload_pcap) {

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -623,6 +623,7 @@ tcpreplay_add_pcapfile(tcpreplay_t *ctx, char *pcap_file)
 
     if (ctx->options->source_cnt < MAX_FILES) {
         ctx->options->sources[ctx->options->source_cnt].filename = safe_strdup(pcap_file);
+        ctx->options->sources[ctx->options->source_cnt].type = source_filename;
 
         /*
          * prepare the cache info data struct.  This doesn't actually enable


### PR DESCRIPTION
This branch increases the accuracy of the --mbps option and removes unnecessary calls to gettimeofday(). Before changes my 10GigE network behaved as follows...

```
root@portwell29:~/tcpreplay-netmap# bin4.0_master/tcpreplay --intf1=eth7 --preload-pcap --mbps=4000 --loop=50 bosTap.pcap 
File Cache is enabled
Actual: 39580750 packets (17770889200 bytes) sent in 45.06 seconds.
Rated: 394382816.0 Bps, 3155.06 Mbps, 878401.00 pps
Statistics for network device: eth7
    Attempted packets:         39580750
    Successful packets:        39580750
    Failed packets:            0
    Retried packets (ENOBUFS): 0
    Retried packets (EAGAIN):  0
```

After changes ...

```
root@portwell29:~/tcpreplay-netmap# bin4.0/tcpreplay --intf1=eth7 --preload-pcap --mbps=4000 --loop=50 bosTap.pcap 
File Cache is enabled
Actual: 39580750 packets (17770889200 bytes) sent in 35.54 seconds.
Rated: 500025024.0 Bps, 4000.20 Mbps, 1113695.88 pps
Statistics for network device: eth7
    Attempted packets:         39580750
    Successful packets:        39580750
    Failed packets:            0
    Retried packets (ENOBUFS): 0
    Retried packets (EAGAIN):  0
```
